### PR TITLE
ci(#85): up to date GitHub Action for TeXLive setup in `codecov.yml`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,9 @@ name: codecov
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 concurrency:
   group: codecov-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - uses: teatimeguest/setup-texlive-action@v3.3.4
+      - uses: zauguin/install-texlive@v4.0.0
         with:
-          update-all-packages: true
           packages: scheme-basic geometry xcolor naive-ebnf microtype etoolbox
+          texlive_version: 2025
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'


### PR DESCRIPTION
In this PR I've updated GitHub Action for TeXLive setup from `teatimeguest/setup-texlive-action` to `zauguin/install-texlive`.

closes #85