### PR TITLE
bug(#82): `lambda` instruction

### DIFF
--- a/src/main/java/org/eolang/sodg/TrSodg.java
+++ b/src/main/java/org/eolang/sodg/TrSodg.java
@@ -53,6 +53,7 @@ final class TrSodg extends TrEnvelope {
                                 ),
                                 "/org/eolang/maven/sodg/add-sodg-root.xsl",
                                 "/org/eolang/maven/sodg/to-sodg.xsl",
+                                "/org/eolang/maven/sodg/drop-lambda.xsl",
                                 "/org/eolang/maven/sodg/applications.xsl"
                             ).back(),
                             new TrDefault<>(

--- a/src/main/resources/org/eolang/maven/sodg/drop-lambda.xsl
+++ b/src/main/resources/org/eolang/maven/sodg/drop-lambda.xsl
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="drop-lambda" version="2.0">
+  <!-- Drop all the lambda as arguments. -->
+  <xsl:import href="/org/eolang/maven/sodg/_macros.xsl"/>
+  <xsl:param name="sheet"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="a[normalize-space(.) = 'λ']"/>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/maven/sodg/to-sodg.xsl
+++ b/src/main/resources/org/eolang/maven/sodg/to-sodg.xsl
@@ -31,10 +31,17 @@
     <xsl:if test="eo:abstract(.)">
       <xsl:call-template name="i">
         <xsl:with-param name="name" select="'formation'"/>
+        <!-- distill each @name with lambda removal -->
         <xsl:with-param name="args" select="(concat('b', position()), o/@name ! string())"/>
       </xsl:call-template>
     </xsl:if>
-    <xsl:for-each select="//o">
+    <xsl:if test="eo:atom(.)">
+      <xsl:call-template name="i">
+        <xsl:with-param name="name" select="'lambda'"/>
+        <xsl:with-param name="args" select="(concat('b', position()), @name)"/>
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:for-each select="//o[not(eo:atom(.))]">
       <xsl:if test="not(eo:abstract(.)) and @base and @name and not(starts-with(@base, 'ξ.'))">
         <xsl:call-template name="i">
           <xsl:with-param name="name" select="'dispatch'"/>

--- a/src/main/resources/org/eolang/maven/sodg/to-sodg.xsl
+++ b/src/main/resources/org/eolang/maven/sodg/to-sodg.xsl
@@ -13,11 +13,11 @@
     </xsl:copy>
   </xsl:template>
   <!--
-  Here we convert all objects into SODG format.
-    @todo #76:30min Implement `lambda(o, name)` instruction.
-     For now we are not handling lambda asset of the object. We should introduce new instruction:
-     `lambda(o, name)` - that would set lambda-asset to particular object. Don't forget to add new
-     test pack and remove this puzzle.
+  Here we convert all objects into SODG format with the following instructions:
+  1. `formation(o, attr0, attr1, ...)`
+  2. `dispatch(o, base, attr)`
+  3. `delta(o, data)`
+  4. `lambda(o, name)`
   -->
   <xsl:template match="/object/sodg">
     <xsl:copy>
@@ -31,7 +31,6 @@
     <xsl:if test="eo:abstract(.)">
       <xsl:call-template name="i">
         <xsl:with-param name="name" select="'formation'"/>
-        <!-- distill each @name with lambda removal -->
         <xsl:with-param name="args" select="(concat('b', position()), o/@name ! string())"/>
       </xsl:call-template>
     </xsl:if>

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/canonical.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/canonical.yaml
@@ -7,7 +7,7 @@ input: |
     qty.mul > cost
       price
 asserts:
-  - //sodg[count(i)=11]
+  - //sodg[count(i[not(@name='comment')])=9]
   - //sodg/i[@name='meta']/a[1][text()='$meta-version']
   - //sodg/i[@name='meta']/a[2][text()='30-2E-35-38-2E-33']
   - //sodg/i[@name='meta']/a[1][text()='$meta-time']

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/delta.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/delta.yaml
@@ -6,7 +6,7 @@ input: |
   [] > foo
     42 > x
 asserts:
-  - //sodg[count(i)=8]
+  - //sodg[count(i[not(@name='comment')])=6]
   - //sodg/i[@name='formation']/a[1][text()='b1']
   - //sodg/i[@name='formation']/a[2][text()='xi🌵']
   - //sodg/i[@name='formation']/a[3][text()='x']

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/nested-with-lambda.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/nested-with-lambda.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 # @todo #82: Enable `nested-with-lambda` test pack after nested `formation()` instructions will be fixed.
 #  Now test is red, since `formation()` instruction works only for root formation `foo`. It should
 #  for all formations. Besides that, collection of object names under formation should go deeper for

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/nested-with-lambda.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/nested-with-lambda.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# @todo #82: Enable `nested-with-lambda` test pack after nested `formation()` instructions will be fixed.
+#  Now test is red, since `formation()` instruction works only for root formation `foo`. It should
+#  for all formations. Besides that, collection of object names under formation should go deeper for
+#  all abstract objects.
+skip: true
+sheets: []
+input: |
+  [] > foo
+    [] > bar
+      [] > baz
+        [] > buz
+          [] > boom ?
+asserts:
+  - //sodg/i[@name='formation' and count(a)=7 and a[1][text()='b1'] and a[2][text()='xi🌵']]
+  - //sodg/i[@name='formation' and a[3][text()='bar'] and a[4][text()='baz'] and a[5][text()='buz'] and a[6][text()='boom']]
+  - //sodg/i[@name='formation' and a[1][text()='b2'] and a[2][text()='xi🌵'] and a[3][text()='baz']]
+  - //sodg/i[@name='formation' and a[1][text()='b3'] and a[2][text()='xi🌵'] and a[3][text()='buz']]
+  - //sodg/i[@name='formation' and a[1][text()='b4'] and a[2][text()='xi🌵'] and a[3][text()='boom']]
+  - //sodg/i[@name='lambda' and count(a)=2 and a[1][text()='b4'] and a[2][text()='boom']]

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/top-lambda.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/top-lambda.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets: []
 input: |
   [] > foo ?

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/top-lambda.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/top-lambda.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+input: |
+  [] > foo ?
+asserts:
+  - //sodg[count(i[not(@name='comment')])=5]
+  - //sodg/i[@name='formation' and count(a)=2 and a[1][text()='b1'] and a[2][text()='xi🌵']]
+  - //sodg/i[@name='lambda' and count(a)=2 and a[1][text()='b1'] and a[2][text()='foo']]
+  - //sodg/i[@name='dispatch' and a[1][text()='b1'] and a[2][text()='b1'] and a[3][text()='xi🌵']]


### PR DESCRIPTION
In this PR I've implemented `lambda(o, name)` instruction, that sets `λ`-asset to the object.

closes #82