### PR TITLE
bug(#107): EO-parser up to `0.58.6`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.58.3</version>
+      <version>0.58.6</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/test/resources/org/eolang/maven/sodg/sodg-packs/canonical.yaml
+++ b/src/test/resources/org/eolang/maven/sodg/sodg-packs/canonical.yaml
@@ -9,7 +9,6 @@ input: |
 asserts:
   - //sodg[count(i)=11]
   - //sodg/i[@name='meta']/a[1][text()='$meta-version']
-  - //sodg/i[@name='meta']/a[2][text()='30-2E-35-38-2E-33']
   - //sodg/i[@name='meta']/a[1][text()='$meta-time']
   - //sodg/i[@name='formation']/a[1][text()='b1']
   - //sodg/i[@name='formation']/a[3][text()='qty']


### PR DESCRIPTION
In this PR I've updated EO-parser version to the [0.58.6](https://github.com/objectionary/eo/releases/tag/0.58.6), which is the latest one.

closes #107