### PR TITLE
bug(#109): `version-up` workflow

### DIFF
--- a/.github/workflows/version-up.yml
+++ b/.github/workflows/version-up.yml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: version-up
+'on':
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+concurrency:
+  group: version-up-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  version-up:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - run: |
+          latest=$(git ls-remote --tags https://github.com/objectionary/sodg-maven-plugin.git | \
+            grep -o 'refs/tags/[0-9]\+\.[0-9]\+\.[0-9]\+' | \
+            sed 's/refs\/tags\///' | \
+            sort -V | \
+            tail -n1)
+          echo "LATEST=$latest" >> "$GITHUB_ENV"
+      - run: |
+          echo "CURRENT=$(sed -nE 's#.*<version>([0-9]+\.[0-9]+\.[0-9]+)</version>.*#\1#p' README.md)" >> "$GITHUB_ENV"
+      - id: check
+        run: |
+          if [ "${{ env.LATEST }}" = "${{ env.CURRENT }}" ]; then
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          else
+            sed -i -E "s#<version>[0-9]+\.[0-9]+\.[0-9]+</version>#<version>${{ env.LATEST }}</version>#g" README.md
+            sed -i -E "s#mvn org.eolang:sodg-maven-plugin:[0-9]+\.[0-9]+\.[0-9]+:sodg#mvn org.eolang:sodg-maven-plugin:${{ env.LATEST }}:sodg#g" README.md
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.check.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          sign-commits: true
+          branch: version-up
+          commit-message: "new version ${{ env.LATEST }} in README"
+          delete-branch: true
+          title: "New version ${{ env.LATEST }} in README"
+          assignees: yegor256
+          base: master

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then, add this plugin to your `pom.xml`:
 <plugin>
    <groupId>org.eolang</groupId>
    <artifactId>sodg-maven-plugin</artifactId>
-   <!-- Check the latest version at Maven central-->
+   <version>0.0.3</version>
    <executions>
       <execution>
          <goals>
@@ -60,7 +60,7 @@ Then, add this plugin to your `pom.xml`:
 Or invoke it directly:
 
 ```bash
-mvn org.eolang:sodg-maven-plugin:<version>:sodg
+mvn org.eolang:sodg-maven-plugin:0.0.3:sodg
 ```
 
 You should see `order.sodg` file being created under `target/eo/sodg` folder,


### PR DESCRIPTION
In this PR I've setup new workflow: `version-up`, that automatically updates `sodg-maven-plugin` versions in `README.md`

see #109