### PR TITLE
bug(#111): `without-pom` invoker test

### DIFF
--- a/src/it/without-pom/README.md
+++ b/src/it/without-pom/README.md
@@ -1,0 +1,10 @@
+# Generates SODG files
+
+Integration test that
+generates [SODG](https://github.com/objectionary/sodg-maven-plugin) files without `pom.xml`.
+
+If you only need to run this test, use the following command:
+
+```shell
+mvn clean integration-test -Dinvoker.test=without-pom -PskipUTs
+```

--- a/src/it/without-pom/README.md
+++ b/src/it/without-pom/README.md
@@ -1,10 +1,11 @@
 # Generates SODG files
 
-Integration test that
-generates [SODG](https://github.com/objectionary/sodg-maven-plugin) files without `pom.xml`.
+Integration test that generates [SODG] files without `pom.xml`.
 
 If you only need to run this test, use the following command:
 
 ```shell
 mvn clean integration-test -Dinvoker.test=without-pom -PskipUTs
 ```
+
+[SODG]: https://github.com/objectionary/sodg-maven-plugin

--- a/src/it/without-pom/invoker.properties
+++ b/src/it/without-pom/invoker.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-sources org.eolang:sodg-maven-plugin:${project.version}:sodg \
+  -Deo.sodg.generateSodgXmlFiles=true

--- a/src/it/without-pom/pom.xml
+++ b/src/it/without-pom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.jcabi</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.70.0</version>
+  </parent>
+  <groupId>org.eolang</groupId>
+  <artifactId>examples</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <name>Generates SODG Files without SODG plugin in pom.xml</name>
+  <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files without the plugin in pom.xml</description>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <failIfNoTests>false</failIfNoTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.58.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>register</goal>
+              <goal>compile</goal>
+              <goal>transpile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skipLinting>true</skipLinting>
+          <unrollExitError>true</unrollExitError>
+          <foreign>${project.build.directory}/eo-foreign.csv</foreign>
+          <foreignFormat>csv</foreignFormat>
+          <placed>${project.build.directory}/eo-placed.csv</placed>
+          <placedFormat>csv</placedFormat>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/without-pom/src/main/eo/org/eolang/sodg/examples/sample.eo
+++ b/src/it/without-pom/src/main/eo/org/eolang/sodg/examples/sample.eo
@@ -1,0 +1,10 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/sodg-maven-plugin
++package org.eolang.sodg.examples
++version 0.0.0
++spdx SPDX-FileCopyrightText Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Sample stuff.
+[n] > sample
+  QQ.io.stdout "Jeff" > @

--- a/src/it/without-pom/verify.groovy
+++ b/src/it/without-pom/verify.groovy
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+String log = new File(basedir, 'build.log').text;
+log.contains("BUILD SUCCESS")
+def generated = new File(basedir, 'target/eo/sodg/org/eolang/sodg/examples/')
+assert generated.toPath().resolve("sample.sodg").toFile().exists()
+assert generated.toPath().resolve("sample.sodg.xml").toFile().exists()
+true

--- a/src/main/java/org/eolang/sodg/MjSodg.java
+++ b/src/main/java/org/eolang/sodg/MjSodg.java
@@ -88,7 +88,7 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Parameter(property = "eo.sodg.foreignFormat", required = true, defaultValue = "csv")
-    protected String foreignFormat = "csv";
+    protected String foreignFormat;
 
     /**
      * File with foreign "tojos".
@@ -96,9 +96,9 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (10 lines)
      */
     @Parameter(
-        property = "eo.foreign",
+        property = "eo.sodg.foreign",
         required = true,
-        defaultValue = "${project.build.directory}/eo-foreign.json"
+        defaultValue = "${project.build.directory}/eo-foreign.csv"
     )
     protected File foreign;
 
@@ -109,7 +109,7 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (10 lines)
      */
     @Parameter(
-        property = "eo.targetDir",
+        property = "eo.sodg.targetDir",
         required = true,
         defaultValue = "${project.build.directory}/eo"
     )
@@ -130,7 +130,7 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
-        property = "eo.generateSodgXmlFiles",
+        property = "eo.sodg.generateSodgXmlFiles",
         defaultValue = "false"
     )
     @SuppressWarnings("PMD.LongVariable")
@@ -166,7 +166,7 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
-        property = "eo.generateDotFiles",
+        property = "eo.sodg.generateDotFiles",
         defaultValue = "false"
     )
     @SuppressWarnings("PMD.LongVariable")
@@ -203,7 +203,7 @@ public final class MjSodg extends AbstractMojo {
         if (this.skip) {
             if (Logger.isInfoEnabled(this)) {
                 Logger.info(
-                    this, "Execution skipped due to eo.skip option"
+                    this, "Execution skipped due to eo.sodg.skip option"
                 );
             }
         } else {


### PR DESCRIPTION
In this PR I've added `without-pom` to test SODG plugin execution without the plugin itself in `pom.xml`.

closes #111