### PR TITLE
#102: Add unit tests for Depot

### DIFF
--- a/src/main/java/org/eolang/sodg/Depot.java
+++ b/src/main/java/org/eolang/sodg/Depot.java
@@ -17,9 +17,6 @@ import org.cactoos.map.MapOf;
 /**
  * The depot that produces trains.
  * @since 0.0.3
- * @todo #9:35min Add unit tests for `Depot`.
- *  We should test the trains inside of it, and method `train()`, that supposed
- *  to return proper train by it's name. Don't forget to remove this puzzle.
  */
 final class Depot {
 

--- a/src/test/java/org/eolang/sodg/DepotTest.java
+++ b/src/test/java/org/eolang/sodg/DepotTest.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.sodg;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Train;
+import java.nio.file.Path;
+import java.util.Map;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link Depot}.
+ *
+ * @since 0.0.3
+ */
+@ExtendWith(MktmpResolver.class)
+final class DepotTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"sodg", "dot", "xembly", "text", "finish"})
+    void returnsTrainByName(final String name, @Mktmp final Path temp) {
+        final Depot depot = new Depot(temp.resolve("measures.csv").toFile());
+        MatcherAssert.assertThat(
+            String.format("Train '%s' must be present in the depot", name),
+            depot.train(name),
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void returnsNullForUnknownName(@Mktmp final Path temp) {
+        final Depot depot = new Depot(temp.resolve("measures.csv").toFile());
+        MatcherAssert.assertThat(
+            "Unknown train name must yield null",
+            depot.train("does-not-exist"),
+            Matchers.nullValue()
+        );
+    }
+
+    @Test
+    void returnsTrainFromCustomMap() {
+        final Train<Shift> train = new com.yegor256.xsline.TrDefault<>();
+        final Map<String, Train<Shift>> trains = new MapOf<>(
+            new MapEntry<>("custom", train)
+        );
+        final Depot depot = new Depot(trains);
+        MatcherAssert.assertThat(
+            "Custom map must expose its train under its key",
+            depot.train("custom"),
+            Matchers.sameInstance(train)
+        );
+    }
+
+    @Test
+    void createsParentDirectoryForMeasuresFile(@Mktmp final Path temp) {
+        final Path measures = temp.resolve("nested").resolve("dir").resolve("measures.csv");
+        new Depot(measures.toFile());
+        MatcherAssert.assertThat(
+            "Parent directory of measures file must be created",
+            measures.getParent().toFile().isDirectory(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsMeasuresPointingToDirectory(@Mktmp final Path temp) {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Depot(temp.toFile()),
+            "Pointing measures to a directory must be rejected"
+        );
+    }
+}


### PR DESCRIPTION
Closes #102.

This PR resolves the PDD puzzle in `Depot.java` (lines 20-22) by adding the missing unit tests and removing the puzzle text.

### Two commits

1. **`#102: add unit tests for Depot covering train(name) and measures-file validation`** — adds `src/test/java/org/eolang/sodg/DepotTest.java` with nine tests:
   - five parameterised cases (`returnsTrainByName`) checking that `train(name)` returns a non-null `Train<Shift>` for every registered name (`sodg`, `dot`, `xembly`, `text`, `finish`),
   - `returnsNullForUnknownName` for the unknown-key path,
   - `returnsTrainFromCustomMap` exercising the `Map`-accepting constructor,
   - `createsParentDirectoryForMeasuresFile` verifying that the constructor creates a missing parent directory for the measures file, and
   - `rejectsMeasuresPointingToDirectory` verifying that pointing the measures path at a directory throws `IllegalArgumentException`.
2. **`#102: remove resolved PDD puzzle from Depot`** — removes the `@todo #9:35min ...` block from the Javadoc of `Depot`.

### Verification

Locally, the new tests are green (`mvn test -Dtest=DepotTest` → `Tests run: 9, Failures: 0, Errors: 0`) and `mvn install -Pqulice -DskipITs` succeeds end to end with the qulice quality profile.

### CI status note

All project-specific checks added or affected by this PR are green: `qulice`, `pdd`, `xcop`, `typos`, `copyrights`, `actionlint`, `yamllint`, `markdown-lint`, `reuse`, `ort`, and `mvn (ubuntu-24.04, 23)` / `mvn (windows-2022, 23)` / `mvn (macos-15, 23)`. Two checks are red, but the failures pre-date this PR and reproduce identically on every recent push to the repository (Renovate updates included; the most recent green `mvn` workflow on `master` is `5b92057` from 2026-01-08):

- **`mvn (ubuntu-24.04, 11)`** — the same Java-11 matrix cell fails on the Renovate runs `25228488336`, `25177041947`, `24957974488`, etc. The failure happens during `mvn clean install` and is independent of the Java sources or tests touched here (Java 23 builds the same code successfully on all three OSes).
- **`codecov`** — fails on the `zauguin/install-texlive` step (`Error: No mirror available`), again independent of any change in this PR; the texlive mirror is intermittently unreachable from the runner.

I ran the build under JDK 11 locally and the unit tests (including the new `DepotTest`) all pass; only the integration tests fail, and only because the runner sandbox blocks `home.objectionary.com` (`HTTP 403 host_not_allowed`), which is a sandbox limitation, not a code problem.
