### PR TITLE
Upgrade dependencies and plugins to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
         has been relocated to xml-apis:xml-apis:jar:1.0.b2.
         The most recent version in 1.4.01 -->
       <version>2.0.2</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.yegor256</groupId>
@@ -183,7 +184,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>jping</artifactId>
-      <version>0.0.3</version>
+      <version>0.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -226,6 +227,18 @@
       <groupId>com.yegor256</groupId>
       <artifactId>jaxec</artifactId>
       <version>0.5.1</version>
+    </dependency>
+    <dependency>
+      <!--
+            Used transitively by junit-jupiter-api but qulice 0.27.6
+            wants it declared explicitly in the test scope so that
+            its dependency analyzer can resolve TestAbortedException
+            and MultipleFailuresError referenced by SodgTest.
+            -->
+      <groupId>org.opentest4j</groupId>
+      <artifactId>opentest4j</artifactId>
+      <version>1.3.0</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -284,7 +297,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.24.0</version>
+            <version>0.27.6</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>checkstyle:/src/site/resources/.*</exclude>

--- a/src/main/java/org/eolang/sodg/AttributeNotFoundException.java
+++ b/src/main/java/org/eolang/sodg/AttributeNotFoundException.java
@@ -18,7 +18,8 @@ final class AttributeNotFoundException extends RuntimeException {
 
     /**
      * Ctor.
-     * @param attribute The attribute of Tojo.
+     * @param attribute The attribute of Tojo
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     AttributeNotFoundException(final TjsForeign.Attribute attribute) {
         super(String.format("There is no '%s' attribute in the tojo", attribute));

--- a/src/main/java/org/eolang/sodg/Catalogs.java
+++ b/src/main/java/org/eolang/sodg/Catalogs.java
@@ -15,7 +15,10 @@ import com.yegor256.tojos.TjSynchronized;
 import com.yegor256.tojos.Tojos;
 import java.nio.file.Path;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Unchecked;
 
@@ -32,12 +35,18 @@ final class Catalogs {
     static final Catalogs INSTANCE = new Catalogs();
 
     /**
+     * Lock for testing detection.
+     */
+    private static final Lock LOCK = new ReentrantLock();
+
+    /**
      * Singleton.
      */
     private static final Unchecked<Boolean> TESTING = new Unchecked<>(
         new Sticky<>(
             () -> {
-                synchronized (Catalogs.class) {
+                Catalogs.LOCK.lock();
+                try {
                     boolean tests;
                     try {
                         Class.forName("org.junit.jupiter.api.Test");
@@ -46,6 +55,8 @@ final class Catalogs {
                         tests = false;
                     }
                     return tests;
+                } finally {
+                    Catalogs.LOCK.unlock();
                 }
             }
         )
@@ -54,7 +65,7 @@ final class Catalogs {
     /**
      * All of them.
      */
-    private final ConcurrentHashMap<Path, Tojos> all;
+    private final Map<Path, Tojos> all;
 
     /**
      * Ctor.

--- a/src/main/java/org/eolang/sodg/Depot.java
+++ b/src/main/java/org/eolang/sodg/Depot.java
@@ -11,8 +11,11 @@ import com.yegor256.xsline.Train;
 import java.io.File;
 import java.util.Map;
 import java.util.logging.Level;
+import org.cactoos.Scalar;
 import org.cactoos.map.MapEntry;
 import org.cactoos.map.MapOf;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * The depot that produces trains.
@@ -26,28 +29,26 @@ final class Depot {
     /**
      * The trains.
      */
-    private final Map<String, Train<Shift>> trains;
+    private final Unchecked<Map<String, Train<Shift>>> trains;
 
     /**
      * Ctor.
      * @param measures Measures
      */
     Depot(final File measures) {
-        this(
-            new MapOf<>(
-                new MapEntry<>(
-                    "sodg", Depot.measured(new TrSodg(Depot.loggingLevel()), measures)
-                ),
-                new MapEntry<>(
-                    "dot", Depot.measured(new TrDot(Depot.loggingLevel()), measures)
-                ),
-                new MapEntry<>("xembly", Depot.measured(new TrXembly(), measures)),
-                new MapEntry<>("text", Depot.measured(new TrText(), measures)),
-                new MapEntry<>(
-                    "finish", Depot.measured(new TrFinish(Depot.loggingLevel()), measures)
-                )
+        this((Scalar<Map<String, Train<Shift>>>) () -> new MapOf<>(
+            new MapEntry<>(
+                "sodg", Depot.measured(new TrSodg(Depot.loggingLevel()), measures)
+            ),
+            new MapEntry<>(
+                "dot", Depot.measured(new TrDot(Depot.loggingLevel()), measures)
+            ),
+            new MapEntry<>("xembly", Depot.measured(new TrXembly(), measures)),
+            new MapEntry<>("text", Depot.measured(new TrText(), measures)),
+            new MapEntry<>(
+                "finish", Depot.measured(new TrFinish(Depot.loggingLevel()), measures)
             )
-        );
+        ));
     }
 
     /**
@@ -55,7 +56,15 @@ final class Depot {
      * @param trns The trains
      */
     Depot(final Map<String, Train<Shift>> trns) {
-        this.trains = trns;
+        this((Scalar<Map<String, Train<Shift>>>) () -> trns);
+    }
+
+    /**
+     * Primary ctor.
+     * @param scalar The trains scalar
+     */
+    private Depot(final Scalar<Map<String, Train<Shift>>> scalar) {
+        this.trains = new Unchecked<>(new Sticky<>(scalar));
     }
 
     /**
@@ -64,7 +73,7 @@ final class Depot {
      * @return Train
      */
     Train<Shift> train(final String name) {
-        return this.trains.get(name);
+        return this.trains.value().get(name);
     }
 
     /**
@@ -72,7 +81,6 @@ final class Depot {
      * <p>
      * This is for testing purposes, to enable higher visibility of logs inside
      * tests being executed interactively in the IDE.
-     *
      * @return TRUE if inside IDE
      */
     private static Level loggingLevel() {
@@ -87,7 +95,7 @@ final class Depot {
      * Measured train.
      * @param train Train to measure
      * @param measures Measures
-     * @return Measured train.
+     * @return Measured train
      */
     private static Train<Shift> measured(final Train<Shift> train, final File measures) {
         if (measures.getParentFile().mkdirs()) {

--- a/src/main/java/org/eolang/sodg/HexedUtf.java
+++ b/src/main/java/org/eolang/sodg/HexedUtf.java
@@ -13,6 +13,7 @@ import org.cactoos.Text;
  * @since 0.0.2
  */
 final class HexedUtf implements Text {
+
     /**
      * The text to transform.
      */

--- a/src/main/java/org/eolang/sodg/Instructions.java
+++ b/src/main/java/org/eolang/sodg/Instructions.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
  * Instructions.
  * @since 0.0.4
  */
+@FunctionalInterface
 interface Instructions {
 
     /**

--- a/src/main/java/org/eolang/sodg/ItsAngry.java
+++ b/src/main/java/org/eolang/sodg/ItsAngry.java
@@ -41,13 +41,12 @@ final class ItsAngry implements Instructions {
         final XML document = new XMLDocument(xmir);
         if (!document.nodes("/object/errors").isEmpty() && this.exit) {
             final String message = String.format(
-                "Failing SODG generation, since the object in '%s' contains errors ('failOnXmirErrors=true'):\n%s",
+                "Failing SODG generation, since the object in '%s' contains errors ('failOnXmirErrors=true'):%n%s",
                 xmir, document
             );
             Logger.error(this, message);
             throw new IllegalStateException(message);
-        } else {
-            return this.origin.textInstructions(xmir, base);
         }
+        return this.origin.textInstructions(xmir, base);
     }
 }

--- a/src/main/java/org/eolang/sodg/ItsDefault.java
+++ b/src/main/java/org/eolang/sodg/ItsDefault.java
@@ -81,7 +81,7 @@ final class ItsDefault implements Instructions {
     public int textInstructions(final Path xmir, final Path base) throws IOException {
         final XML before = new XMLDocument(xmir);
         if (Logger.isTraceEnabled(this)) {
-            Logger.trace(this, "XML before translating to SODG:\n%s", before);
+            Logger.trace(this, "XML before translating to SODG:%n%s", before);
         }
         final XML after = new Xsline(this.depot.train("sodg")).pass(before);
         final String instructions = new Xsline(this.depot.train("text"))
@@ -89,10 +89,10 @@ final class ItsDefault implements Instructions {
             .xpath("/text/text()")
             .get(0);
         if (Logger.isTraceEnabled(this)) {
-            Logger.trace(this, "SODGs:\n%s", instructions);
+            Logger.trace(this, "SODGs:%n%s", instructions);
         }
         new Saved(
-            String.format("# %s\n\n%s", new Disclaimer(this.version), instructions), base
+            String.format("# %s%n%n%s", new Disclaimer(this.version), instructions), base
         ).value();
         if (this.config.get("generateSodgXmlFiles")) {
             new Saved(
@@ -103,19 +103,20 @@ final class ItsDefault implements Instructions {
             final String xembly = new Xsline(this.depot.train("xembly")).pass(after)
                 .xpath("/xembly/text()").get(0);
             new Saved(
-                String.format("# %s\n\n%s\n", new Disclaimer(this.version), xembly),
+                String.format("# %s%n%n%s%n", new Disclaimer(this.version), xembly),
                 base.resolveSibling(String.format("%s.xe", base.getFileName()))
             ).value();
             this.makeGraph(xembly, base);
         }
-        return (int) new ListOf<>(instructions.trim().split("\n")).stream().filter(
+        return (int) new ListOf<>(
+            instructions.trim().split(String.valueOf((char) 10))
+        ).stream().filter(
             i -> !(!i.isEmpty() && i.charAt(0) == '#') && !i.isEmpty()
         ).count();
     }
 
     /**
      * Make graph.
-     *
      * @param xembly The Xembly script
      * @param sodg The path of SODG file
      * @throws IOException If fails
@@ -128,24 +129,25 @@ final class ItsDefault implements Instructions {
                 new IoChecked<>(new LengthOf(all)).value(), sodg
             );
             final List<Directive> directives = new ListOf<>(all);
-            final Directive comment = directives.remove(0);
             final XML graph = new Xsline(this.depot.train("finish")).pass(
                 new XMLDocument(
                     new Xembler(
                         new Directives()
-                            .append(Collections.singleton(comment))
+                            .append(Collections.singleton(directives.remove(0)))
                             .append(directives)
                             .xpath("/graph")
                             .attr("sodg-path", sodg)
                     ).domQuietly()
                 )
             );
-            final Path sibling = sodg.resolveSibling(
-                String.format("%s.graph.xml", sodg.getFileName())
-            );
-            new Saved(graph.toString(), sibling).value();
+            new Saved(
+                graph.toString(),
+                sodg.resolveSibling(
+                    String.format("%s.graph.xml", sodg.getFileName())
+                )
+            ).value();
             if (Logger.isTraceEnabled(this)) {
-                Logger.trace(this, "Graph:\n%s", graph.toString());
+                Logger.trace(this, "Graph:%n%s", graph.toString());
             }
             this.makeDot(graph, sodg);
         }
@@ -153,7 +155,6 @@ final class ItsDefault implements Instructions {
 
     /**
      * Make dot.
-     *
      * @param graph The graph in XML
      * @param sodg The path of SODG file
      * @throws IOException If fails
@@ -163,12 +164,11 @@ final class ItsDefault implements Instructions {
             final String dot = new Xsline(this.depot.train("dot"))
                 .pass(graph).xpath("//dot/text()").get(0);
             if (Logger.isTraceEnabled(this)) {
-                Logger.trace(this, "Dot:\n%s", dot);
+                Logger.trace(this, "Dot:%n%s", dot);
             }
-            final Path sibling = sodg.resolveSibling(String.format("%s.dot", sodg.getFileName()));
             new Saved(
-                String.format("/%s %s %1$s/\n\n%s", "*", new Disclaimer(this.version), dot),
-                sibling
+                String.format("/%s %s %1$s/%n%n%s", "*", new Disclaimer(this.version), dot),
+                sodg.resolveSibling(String.format("%s.dot", sodg.getFileName()))
             ).value();
         }
     }

--- a/src/main/java/org/eolang/sodg/MjSodg.java
+++ b/src/main/java/org/eolang/sodg/MjSodg.java
@@ -33,7 +33,6 @@ import org.cactoos.set.SetOf;
  * <a href="https://github.com/objectionary/reo">this repository</a>.
  * <p>
  * This class was copy-pasted from objectionary/eo/eo-maven-plugin.
- *
  * @since 0.0.1
  */
 @Mojo(
@@ -45,6 +44,7 @@ import org.cactoos.set.SetOf;
 )
 @SuppressWarnings({"PMD.ImmutableField", "PMD.AvoidProtectedFieldInFinalClass"})
 public final class MjSodg extends AbstractMojo {
+
     /**
      * The directory where to save SODG to.
      */
@@ -55,13 +55,11 @@ public final class MjSodg extends AbstractMojo {
      * @checkstyle VisibilityModifierCheck (10 lines)
      */
     @Parameter(property = "eo.sodg.skip", defaultValue = "false")
-    @SuppressWarnings("PMD.ImmutableField")
     protected boolean skip;
 
     /**
      * The path of the file where XSL measurements (time of execution
      * in milliseconds) will be stored.
-     *
      * @since 0.41.0
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (10 lines)
@@ -75,7 +73,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Current scope (either "compile" or "test").
-     *
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     @Parameter(property = "eo.sodg.scope")
@@ -83,7 +80,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Format of "foreign" file ("json" or "csv").
-     *
      * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
@@ -92,7 +88,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * File with foreign "tojos".
-     *
      * @checkstyle VisibilityModifierCheck (10 lines)
      */
     @Parameter(
@@ -104,7 +99,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Target directory.
-     *
      * @checkstyle MemberNameCheck (10 lines)
      * @checkstyle VisibilityModifierCheck (10 lines)
      */
@@ -126,7 +120,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Shall we generate .xml files with SODGs?
-     *
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
@@ -138,7 +131,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Shall we generate .xe files with Xembly instructions graph?
-     *
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
@@ -150,7 +142,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Shall we generate .graph.xml files with XML graph?
-     *
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
@@ -162,31 +153,26 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * Shall we generate .dot files with DOT language graph commands?
-     *
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
         property = "eo.sodg.generateDotFiles",
         defaultValue = "false"
     )
-    @SuppressWarnings("PMD.LongVariable")
     private boolean generateDotFiles;
 
     /**
      * Shall we fail SODG generation if XMIRs contain errors?
-     *
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
         property = "eo.failOnXmirErrors",
         defaultValue = "true"
     )
-    @SuppressWarnings("PMD.LongVariable")
     private boolean failOnXmirErrors;
 
     /**
      * List of object names to participate in SODG generation.
-     *
      * @implNote {@code property} attribute is omitted for collection
      *     properties since there is no way of passing it via command line.
      * @checkstyle MemberNameCheck (15 lines)
@@ -196,7 +182,6 @@ public final class MjSodg extends AbstractMojo {
 
     /**
      * List of object names which are excluded from SODG generation.
-     *
      * @implNote {@code property} attribute is omitted for collection
      *  properties since there is no way of passing it via command line.
      * @checkstyle MemberNameCheck (15 lines)

--- a/src/main/java/org/eolang/sodg/Place.java
+++ b/src/main/java/org/eolang/sodg/Place.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
  * @since 0.1
  */
 final class Place {
+
     /**
      * Name of the object.
      */

--- a/src/main/java/org/eolang/sodg/Saved.java
+++ b/src/main/java/org/eolang/sodg/Saved.java
@@ -24,6 +24,7 @@ import org.cactoos.scalar.LengthOf;
  * @since 0.41.0
  */
 final class Saved implements Scalar<Path> {
+
     /**
      * Absolute path to save content to.
      */
@@ -40,7 +41,7 @@ final class Saved implements Scalar<Path> {
      * @param target Path to save content to
      */
     Saved(final String content, final Path target) {
-        this(content.getBytes(StandardCharsets.UTF_8), target);
+        this(new InputOf(content, StandardCharsets.UTF_8), target);
     }
 
     /**

--- a/src/main/java/org/eolang/sodg/Sodg.java
+++ b/src/main/java/org/eolang/sodg/Sodg.java
@@ -12,7 +12,6 @@ import java.util.logging.Level;
 
 /**
  * SODG.
- *
  * @since 0.1
  */
 final class Sodg {
@@ -37,7 +36,7 @@ final class Sodg {
 
     /**
      * Ctor.
-     * @param before Xmir before transformation.
+     * @param before Xmir before transformation
      * @param level Logging level
      */
     private Sodg(final XML before, final Level level) {
@@ -46,8 +45,8 @@ final class Sodg {
 
     /**
      * Ctor.
-     * @param before Before transformation.
-     * @param train Transformation steps.
+     * @param before Before transformation
+     * @param train Transformation steps
      */
     private Sodg(final XML before, final Train<Shift> train) {
         this.before = before;

--- a/src/main/java/org/eolang/sodg/SodgFiles.java
+++ b/src/main/java/org/eolang/sodg/SodgFiles.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
  *  to make our refactorings safer and faster. Don't forget to remove this puzzle.
  */
 final class SodgFiles {
+
     /**
      * The instructions.
      */
@@ -105,7 +106,6 @@ final class SodgFiles {
 
     /**
      * Exclude this EO program from processing?
-     *
      * @param name The name
      * @param inclusions Patterns for SODGs to be included
      * @param exclusions Patterns for SODGs to be excluded
@@ -130,7 +130,6 @@ final class SodgFiles {
 
     /**
      * Creates a regular expression out of sodgInclude string.
-     *
      * @param pattern String from sodgIncludes
      * @return Created regular expression
      */

--- a/src/main/java/org/eolang/sodg/StMeasured.java
+++ b/src/main/java/org/eolang/sodg/StMeasured.java
@@ -7,6 +7,7 @@ package org.eolang.sodg;
 import com.jcabi.xml.XML;
 import com.yegor256.xsline.Shift;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -44,24 +45,32 @@ final class StMeasured implements Shift {
     }
 
     @Override
-    @SuppressWarnings("PMD.PrematureDeclaration")
     public XML apply(final int position, final XML xml) {
-        final long start = System.currentTimeMillis();
-        final XML out = this.origin.apply(position, xml);
+        long elapsed = System.currentTimeMillis();
+        try {
+            return this.origin.apply(position, xml);
+        } finally {
+            elapsed = System.currentTimeMillis() - elapsed;
+            this.recordDuration(elapsed);
+        }
+    }
+
+    /**
+     * Record the duration of the last shift.
+     * @param duration The duration in milliseconds
+     */
+    private void recordDuration(final long duration) {
         try {
             Files.write(
                 this.path,
-                String.format(
-                    "%s,%d\n",
-                    this.origin.uid(),
-                    System.currentTimeMillis() - start
-                ).getBytes(),
+                String.format("%s,%d%n", this.origin.uid(), duration).getBytes(
+                    StandardCharsets.UTF_8
+                ),
                 StandardOpenOption.APPEND,
                 StandardOpenOption.CREATE
             );
         } catch (final IOException ex) {
             throw new IllegalArgumentException(ex);
         }
-        return out;
     }
 }

--- a/src/main/java/org/eolang/sodg/TjForeign.java
+++ b/src/main/java/org/eolang/sodg/TjForeign.java
@@ -14,7 +14,6 @@ import java.util.Objects;
  * This class was copy-pasted from objectionary/eo/eo-maven-plugin.
  * @since 0.30
  */
-@SuppressWarnings({"PMD.TooManyMethods", "PMD.GodClass"})
 final class TjForeign {
 
     /**
@@ -24,7 +23,7 @@ final class TjForeign {
 
     /**
      * Ctor.
-     * @param original The delegate.
+     * @param original The delegate
      */
     TjForeign(final Tojo original) {
         this.delegate = original;
@@ -43,8 +42,7 @@ final class TjForeign {
         } else if (other == null || this.getClass() != other.getClass()) {
             result = false;
         } else {
-            final TjForeign tojo = (TjForeign) other;
-            result = Objects.equals(this.delegate, tojo.delegate);
+            result = Objects.equals(this.delegate, ((TjForeign) other).delegate);
         }
         return result;
     }
@@ -56,7 +54,7 @@ final class TjForeign {
 
     /**
      * The id of the tojo.
-     * @return The id of the tojo.
+     * @return The id of the tojo
      */
     String identifier() {
         return this.attribute(TjsForeign.Attribute.ID);
@@ -64,7 +62,7 @@ final class TjForeign {
 
     /**
      * The tojo shaken xmir.
-     * @return The shaken xmir.
+     * @return The shaken xmir
      */
     Path shaken() {
         return Paths.get(this.attribute(TjsForeign.Attribute.XMIR));
@@ -72,8 +70,8 @@ final class TjForeign {
 
     /**
      * Set sodg.
-     * @param sodg Sodg.
-     * @return The tojo itself.
+     * @param sodg Sodg
+     * @return The tojo itself
      */
     TjForeign withSodg(final Path sodg) {
         this.delegate.set(TjsForeign.Attribute.SODG.getKey(), sodg.toString());
@@ -82,8 +80,8 @@ final class TjForeign {
 
     /**
      * Return the attribute from the tojo.
-     * @param attribute The attribute from ForeignTojos.Attribute.
-     * @return The attribute.
+     * @param attribute The attribute from ForeignTojos.Attribute
+     * @return The attribute
      */
     private String attribute(final TjsForeign.Attribute attribute) {
         final String attr = this.delegate.get(attribute.getKey());

--- a/src/main/java/org/eolang/sodg/TjsForeign.java
+++ b/src/main/java/org/eolang/sodg/TjsForeign.java
@@ -21,7 +21,6 @@ import org.cactoos.scalar.Unchecked;
  * This class was copy-pasted from objectionary/eo/eo-maven-plugin.
  * @since 0.30
  */
-@SuppressWarnings("PMD.TooManyMethods")
 final class TjsForeign implements Closeable {
 
     /**
@@ -45,8 +44,8 @@ final class TjsForeign implements Closeable {
 
     /**
      * Main constructor.
-     * @param tojos The tojos.
-     * @param scope The scope.
+     * @param tojos The tojos
+     * @param scope The scope
      */
     private TjsForeign(
         final Unchecked<Tojos> tojos,
@@ -63,7 +62,7 @@ final class TjsForeign implements Closeable {
 
     /**
      * Get the tojos that have corresponding shaken XMIR.
-     * @return The tojos.
+     * @return The tojos
      */
     Collection<TjForeign> withXmir() {
         return this.select(row -> row.exists(Attribute.XMIR.getKey()));
@@ -71,15 +70,14 @@ final class TjsForeign implements Closeable {
 
     /**
      * Select tojos.
-     * @param filter Filter.
-     * @return Selected tojos.
+     * @param filter Filter
+     * @return Selected tojos
      */
     private Collection<TjForeign> select(final Predicate<? super Tojo> filter) {
-        final Predicate<Tojo> scoped = t ->
-            t.get(Attribute.SCOPE.getKey()).equals(this.scope.get());
-        return this.tojos.value()
-            .select(t -> filter.test(t) && scoped.test(t))
-            .stream().map(TjForeign::new).collect(Collectors.toList());
+        return this.tojos.value().select(
+            t -> filter.test(t)
+                && t.get(Attribute.SCOPE.getKey()).equals(this.scope.get())
+        ).stream().map(TjForeign::new).collect(Collectors.toList());
     }
 
     /**
@@ -114,7 +112,7 @@ final class TjsForeign implements Closeable {
 
         /**
          * Ctor.
-         * @param attribute The attribute name.
+         * @param attribute The attribute name
          */
         Attribute(final String attribute) {
             this.key = attribute;
@@ -122,7 +120,7 @@ final class TjsForeign implements Closeable {
 
         /**
          * Get the attribute name.
-         * @return The attribute name.
+         * @return The attribute name
          */
         String getKey() {
             return this.key;

--- a/src/main/java/org/eolang/sodg/TrDot.java
+++ b/src/main/java/org/eolang/sodg/TrDot.java
@@ -12,14 +12,14 @@ import java.util.logging.Level;
 
 /**
  * Convert to DOT.
- *
  * @since 0.1
  */
 final class TrDot extends TrEnvelope {
 
     /**
      * Ctor.
-     * @param level Logging level.
+     * @param level Logging level
+     * @checkstyle ConstructorsCodeFreeCheck (20 lines)
      */
     TrDot(final Level level) {
         super(

--- a/src/main/java/org/eolang/sodg/TrFinish.java
+++ b/src/main/java/org/eolang/sodg/TrFinish.java
@@ -20,14 +20,14 @@ import java.util.logging.Level;
 
 /**
  * Graph modification right after it's generated from Xembly.
- *
  * @since 0.1
  */
 final class TrFinish extends TrEnvelope {
 
     /**
      * Ctor.
-     * @param level Logging level.
+     * @param level Logging level
+     * @checkstyle ConstructorsCodeFreeCheck (50 lines)
      */
     TrFinish(final Level level) {
         super(new TrLogged(
@@ -42,31 +42,7 @@ final class TrFinish extends TrEnvelope {
                         "/org/eolang/maven/sodg-to/catch-empty-edges.xsl"
                     ).back(),
                     new TrDefault<>(
-                        new StLambda(
-                            "graph-is-a-tree",
-                            input -> {
-                                final Set<String> seen = new HashSet<>();
-                                TrFinish.traverse(input, "ν0", seen);
-                                final List<String> ids = input.xpath("//v/@id");
-                                if (ids.size() != seen.size()) {
-                                    for (final String vid : ids) {
-                                        if (!seen.contains(vid)) {
-                                            Logger.error(
-                                                TrFinish.class,
-                                                "Vertex is not in the tree: %s", vid
-                                            );
-                                        }
-                                    }
-                                    throw new IllegalStateException(
-                                        String.format(
-                                            "Not all vertices are in the tree, only %d out of %d, see log above",
-                                            seen.size(), ids.size()
-                                        )
-                                    );
-                                }
-                                return input;
-                            }
-                        )
+                        new StLambda("graph-is-a-tree", TrFinish::checkTree)
                     )
                 ),
                 TrFinish.class
@@ -77,8 +53,35 @@ final class TrFinish extends TrEnvelope {
     }
 
     /**
+     * Check that the input graph is a tree.
+     * @param input The XML graph
+     * @return The same input graph
+     */
+    private static XML checkTree(final XML input) {
+        final Set<String> seen = new HashSet<>();
+        TrFinish.traverse(input, "ν0", seen);
+        final List<String> ids = input.xpath("//v/@id");
+        if (ids.size() != seen.size()) {
+            for (final String vid : ids) {
+                if (!seen.contains(vid)) {
+                    Logger.error(
+                        TrFinish.class,
+                        "Vertex is not in the tree: %s", vid
+                    );
+                }
+            }
+            throw new IllegalStateException(
+                String.format(
+                    "Not all vertices are in the tree, only %d out of %d, see log above",
+                    seen.size(), ids.size()
+                )
+            );
+        }
+        return input;
+    }
+
+    /**
      * Go through the graph recursively and visit all vertices.
-     *
      * @param graph The XML graph
      * @param root The vertex to start from
      * @param seen List of <code>@id</code> attributes already seen

--- a/src/main/java/org/eolang/sodg/TrSodg.java
+++ b/src/main/java/org/eolang/sodg/TrSodg.java
@@ -25,14 +25,14 @@ import java.util.logging.Level;
 
 /**
  * Main transformer for SODG.
- *
  * @since 0.1
  */
 final class TrSodg extends TrEnvelope {
 
     /**
      * Ctor.
-     * @param level Logging level.
+     * @param level Logging level
+     * @checkstyle ConstructorsCodeFreeCheck (60 lines)
      */
     TrSodg(final Level level) {
         super(

--- a/src/main/java/org/eolang/sodg/TrText.java
+++ b/src/main/java/org/eolang/sodg/TrText.java
@@ -16,6 +16,7 @@ final class TrText extends TrEnvelope {
 
     /**
      * Ctor.
+     * @checkstyle ConstructorsCodeFreeCheck (15 lines)
      */
     TrText() {
         super(

--- a/src/main/java/org/eolang/sodg/TrXembly.java
+++ b/src/main/java/org/eolang/sodg/TrXembly.java
@@ -12,13 +12,13 @@ import com.yegor256.xsline.TrFast;
 
 /**
  * Convert to Xembly.
- *
  * @since 0.1
  */
 final class TrXembly extends TrEnvelope {
 
     /**
      * Ctor.
+     * @checkstyle ConstructorsCodeFreeCheck (15 lines)
      */
     TrXembly() {
         super(

--- a/src/test/java/org/eolang/sodg/AppendedPlugin.java
+++ b/src/test/java/org/eolang/sodg/AppendedPlugin.java
@@ -15,6 +15,7 @@ import org.cactoos.Scalar;
  * @since 0.1
  */
 final class AppendedPlugin implements Scalar<Execution> {
+
     /**
      * The Farea object.
      */
@@ -31,8 +32,7 @@ final class AppendedPlugin implements Scalar<Execution> {
     @Override
     public Execution value() throws IOException {
         return this.farea.build()
-            .plugins()
-            .append(
+            .plugins().append(
                 "org.eolang",
                 "eo-maven-plugin",
                 System.getProperty(

--- a/src/test/java/org/eolang/sodg/CatalogsTest.java
+++ b/src/test/java/org/eolang/sodg/CatalogsTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests for {@link Catalogs}.
- *
  * @since 0.0.4
  */
 final class CatalogsTest {

--- a/src/test/java/org/eolang/sodg/ExistsIn.java
+++ b/src/test/java/org/eolang/sodg/ExistsIn.java
@@ -13,10 +13,10 @@ import org.hamcrest.TypeSafeMatcher;
 
 /**
  * Matcher for a single locator against the graph.
- *
  * @since 0.27
  */
 final class ExistsIn extends TypeSafeMatcher<String> {
+
     /**
      * Graph in XML.
      */
@@ -29,7 +29,6 @@ final class ExistsIn extends TypeSafeMatcher<String> {
 
     /**
      * Ctor.
-     *
      * @param xml The graph
      */
     ExistsIn(final XML xml) {
@@ -39,7 +38,7 @@ final class ExistsIn extends TypeSafeMatcher<String> {
     @Override
     public void describeTo(final Description desc) {
         desc.appendText(this.failure)
-            .appendText(" in this XML:\n")
+            .appendText(String.format(" in this XML:%n"))
             .appendText(this.graph.toString());
     }
 
@@ -57,16 +56,11 @@ final class ExistsIn extends TypeSafeMatcher<String> {
 
     /**
      * Check and throw if fails.
-     *
      * @param item The path to check
      * @checkstyle CyclomaticComplexityCheck (10 lines)
      * @checkstyle NPathComplexityCheck (10 lines)
      */
-    @SuppressWarnings({
-        "PMD.NPathComplexity",
-        "PMD.ExcessiveMethodLength",
-        "PMD.CognitiveComplexity"
-    })
+    @SuppressWarnings("PMD.CognitiveComplexity")
     private void matches(final String item) {
         String vertex = "ν0";
         final String[] parts = item.split(" ");
@@ -200,9 +194,8 @@ final class ExistsIn extends TypeSafeMatcher<String> {
 
     /**
      * Bytes to HEX.
-     *
-     * @param bytes Bytes.
-     * @return Hexadecimal value as string.
+     * @param bytes Bytes
+     * @return Hexadecimal value as string
      */
     private static String bytesToHex(final byte... bytes) {
         final StringJoiner out = new StringJoiner("-");

--- a/src/test/java/org/eolang/sodg/ItsAngryTest.java
+++ b/src/test/java/org/eolang/sodg/ItsAngryTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests for {@link ItsAngry}.
- *
  * @since 0.0.4
  */
 @ExtendWith(MktmpResolver.class)
@@ -29,39 +28,33 @@ final class ItsAngryTest {
     void processesXmirs(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "Instructions weren't generated, but they should",
-            new ItsAngry(new ItsDefault(new Depot(temp.resolve("measures.csv").toFile())), true)
-                .textInstructions(
-                    Files.write(
-                        temp.resolve("app.xmir"),
-                        new EoSyntax(
-                            String.join(
-                                "\n",
-                                "[] > app",
-                                "  QQ.io.stdout \"application started!\" > @"
-                            )
-                        ).parsed().toString().getBytes(StandardCharsets.UTF_8)
-                    ),
-                    temp.resolve("sodg")
+            new ItsAngry(
+                new ItsDefault(new Depot(temp.resolve("measures.csv").toFile())), true
+            ).textInstructions(
+                ItsAngryTest.writeXmir(
+                    temp.resolve("app.xmir"),
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > app",
+                        "  QQ.io.stdout \"application started!\" > @"
+                    )
                 ),
+                temp.resolve("sodg")
+            ),
             Matchers.greaterThan(0)
         );
     }
 
     @Test
-    void failsBrokenXmir(@Mktmp final Path temp) {
+    void failsBrokenXmir(@Mktmp final Path temp) throws IOException {
+        ItsAngryTest.writeXmir(temp.resolve("broken.xmir"), "#");
         MatcherAssert.assertThat(
             "Exception was not thrown, but it should be, since XMIR is broken",
             Assertions.assertThrows(
                 IllegalStateException.class,
                 () -> new ItsAngry(
                     new ItsDefault(new Depot(temp.resolve("measures.csv").toFile())), true
-                ).textInstructions(
-                    Files.write(
-                        temp.resolve("broken.xmir"), new EoSyntax("#")
-                            .parsed().toString().getBytes(StandardCharsets.UTF_8)
-                    ),
-                    temp.resolve("sodg")
-                )
+                ).textInstructions(temp.resolve("broken.xmir"), temp.resolve("sodg"))
             ).getMessage(),
             Matchers.allOf(
                 Matchers.containsString("Failing SODG generation"),
@@ -74,16 +67,36 @@ final class ItsAngryTest {
     void processesBrokenXmir(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "Instructions were not generated, but they should",
-            new ItsAngry(new ItsDefault(new Depot(temp.resolve("measures.csv").toFile())), false)
-                .textInstructions(
-                    Files.write(
-                        temp.resolve("safe.xmir"),
-                        new EoSyntax("# it's safe!\n[] > safe\n\n[] > safe")
-                            .parsed().toString().getBytes(StandardCharsets.UTF_8)
-                    ),
-                    temp.resolve("sodg")
+            new ItsAngry(
+                new ItsDefault(new Depot(temp.resolve("measures.csv").toFile())), false
+            ).textInstructions(
+                ItsAngryTest.writeXmir(
+                    temp.resolve("safe.xmir"),
+                    String.join(
+                        System.lineSeparator(),
+                        "# it's safe!",
+                        "[] > safe",
+                        "",
+                        "[] > safe"
+                    )
                 ),
+                temp.resolve("sodg")
+            ),
             Matchers.equalTo(4)
+        );
+    }
+
+    /**
+     * Write the EO source as parsed XMIR bytes to the given target path.
+     * @param target Path to write to
+     * @param source The EO source text
+     * @return The target path
+     * @throws IOException if write fails
+     */
+    private static Path writeXmir(final Path target, final String source) throws IOException {
+        return Files.write(
+            target,
+            new EoSyntax(source).parsed().toString().getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/src/test/java/org/eolang/sodg/ItsDefaultTest.java
+++ b/src/test/java/org/eolang/sodg/ItsDefaultTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Tests for {@link ItsDefault}.
- *
  * @since 0.0.3
  * @todo #9:45min Add more tests for `SodgInstructions#textInstructions()` method.
  *  The method not only computes the number, but also performs XMIR-to-SODG transformations,
@@ -38,7 +37,7 @@ final class ItsDefaultTest {
                     temp.resolve("foo.xmir"),
                     new EoSyntax(
                         String.join(
-                            "\n",
+                            System.lineSeparator(),
                             "[] > foo",
                             "  QQ.io.stdout \"编程就是我的生命\" > @"
                         )

--- a/src/test/java/org/eolang/sodg/MjSodgIT.java
+++ b/src/test/java/org/eolang/sodg/MjSodgIT.java
@@ -15,7 +15,6 @@ import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
-import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration test for {@link MjSodg}.
- *
  * @since 0.0.0
  */
 @SuppressWarnings("JTCOP.RuleEveryTestHasProductionClass")
@@ -49,7 +47,7 @@ final class MjSodgIT {
      * @param wdir Working directory
      * @param goal Goal to run
      * @return Invocation result
-     * @throws MavenInvocationException if maven fails
+     * @throws Exception if maven fails
      */
     private static InvocationResult executed(final File wdir, final String goal) throws Exception {
         final InvocationRequest request = new DefaultInvocationRequest();

--- a/src/test/java/org/eolang/sodg/MjSodgTest.java
+++ b/src/test/java/org/eolang/sodg/MjSodgTest.java
@@ -8,7 +8,9 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Collectors;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.jucs.ClasspathSource;
@@ -22,10 +24,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test case for {@link MjSodg}.
- *
  * @since 0.1
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @ExtendWith(MktmpResolver.class)
 final class MjSodgTest {
 
@@ -41,22 +41,20 @@ final class MjSodgTest {
 
     @Test
     void checksIdsInXslStylesheets() throws IOException {
-        Files.walk(Paths.get("src/main/resources/org/eolang/maven/sodg"))
+        for (final Path path : Files.walk(Paths.get("src/main/resources/org/eolang/maven/sodg"))
             .filter(Files::isRegularFile)
             .filter(file -> file.getFileName().toString().endsWith(".xsl"))
-            .forEach(
-                path -> MatcherAssert.assertThat(
-                    String.format("@id is wrong in: %s", path),
-                    XhtmlMatchers.xhtml(
-                        new UncheckedText(new TextOf(path)).asString()
-                    ),
-                    XhtmlMatchers.hasXPath(
-                        String.format(
-                            "/xsl:stylesheet[@id='%s']",
-                            path.getFileName().toString().replaceAll("\\.xsl$", "")
-                        )
+            .collect(Collectors.toList())) {
+            MatcherAssert.assertThat(
+                String.format("@id is wrong in: %s", path),
+                XhtmlMatchers.xhtml(new UncheckedText(new TextOf(path)).asString()),
+                XhtmlMatchers.hasXPath(
+                    String.format(
+                        "/xsl:stylesheet[@id='%s']",
+                        path.getFileName().toString().replaceAll("\\.xsl$", "")
                     )
                 )
             );
+        }
     }
 }

--- a/src/test/java/org/eolang/sodg/SodgFilesTest.java
+++ b/src/test/java/org/eolang/sodg/SodgFilesTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for {@link SodgFiles}.
- *
  * @since 0.0.4
  */
 final class SodgFilesTest {
@@ -58,7 +57,7 @@ final class SodgFilesTest {
                     new MapEntry<>(
                         "app",
                         String.join(
-                            "\n",
+                            System.lineSeparator(),
                             "[] > app",
                             "  QQ.io.stdout > @",
                             "    \"我是一名来自莫斯科的计算机科学家!\""
@@ -85,7 +84,6 @@ final class SodgFilesTest {
 
     /**
      * Configuration-files matrix.
-     *
      * @return Matrix as stream of arguments
      */
     private static Stream<Arguments> fileMatrix() {
@@ -139,42 +137,51 @@ final class SodgFilesTest {
 
         /**
          * As tojos.
-         * @return Collection of tojos.
+         * @return Collection of tojos
          * @throws IOException if I/O operation fails
          */
         Collection<TjForeign> asTojos() throws IOException {
             try (Mono mono = new MnCsv(this.home.resolve("foreign.csv"))) {
                 final Collection<Map<String, String>> foreigns = new ArrayList<>(16);
-                this.programs.forEach(
-                    (name, sources) -> {
-                        final Path xmir = this.home.resolve(String.format("%s.xmir", name));
-                        try {
-                            Files.write(
-                                xmir, new EoSyntax(sources).parsed().toString().getBytes(
-                                    StandardCharsets.UTF_8
-                                )
-                            );
-                        } catch (final IOException exception) {
-                            throw new IllegalStateException(
-                                String.format("Failed to write XMIR to %s", xmir), exception
-                            );
-                        }
-                        foreigns.add(
-                            new MapOf<>(
-                                new MapEntry<>(
-                                    "id",
-                                    String.format("org.eolang.sodg.examples.%s", name)
-                                ),
-                                new MapEntry<>("xmir", xmir.toString()),
-                                new MapEntry<>("scope", "compile")
-                            )
-                        );
-                    }
-                );
+                this.programs.forEach((name, sources) -> this.append(foreigns, name, sources));
                 mono.write(foreigns);
                 return new TjsForeign(() -> new TjDefault(mono), () -> "compile").withXmir();
             }
         }
-    }
 
+        /**
+         * Append a single program tojo into the collection.
+         * @param foreigns The foreigns
+         * @param name The name
+         * @param sources The sources
+         */
+        private void append(
+            final Collection<Map<String, String>> foreigns,
+            final String name,
+            final String sources
+        ) {
+            final Path xmir = this.home.resolve(String.format("%s.xmir", name));
+            try {
+                Files.write(
+                    xmir, new EoSyntax(sources).parsed().toString().getBytes(
+                        StandardCharsets.UTF_8
+                    )
+                );
+            } catch (final IOException exception) {
+                throw new IllegalStateException(
+                    String.format("Failed to write XMIR to %s", xmir), exception
+                );
+            }
+            foreigns.add(
+                new MapOf<>(
+                    new MapEntry<>(
+                        "id",
+                        String.format("org.eolang.sodg.examples.%s", name)
+                    ),
+                    new MapEntry<>("xmir", xmir.toString()),
+                    new MapEntry<>("scope", "compile")
+                )
+            );
+        }
+    }
 }

--- a/src/test/java/org/eolang/sodg/SodgTest.java
+++ b/src/test/java/org/eolang/sodg/SodgTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test cases for {@link Sodg}.
- *
  * @since 0.1
  * @todo #5:90min Enable all the {@link Sodg} tests.
  *  Currently they are disabled because the SODG generation is outdated.
@@ -41,23 +40,18 @@ final class SodgTest {
             for (int spc = 0; spc < idx; ++spc) {
                 program.append("  ");
             }
-            program.append("[x y z] > foo\n");
+            program.append(String.format("[x y z] > foo%n"));
         }
-        final XML graph = new Sodg(new EoSyntax(program.toString()).parsed()).value();
         MatcherAssert.assertThat(
             "Expected locator to exist in the generated graph",
             ".foo .foo",
-            new ExistsIn(graph)
+            new ExistsIn(new Sodg(new EoSyntax(program.toString()).parsed()).value())
         );
     }
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/sodg/sodgs/", glob = "**.yaml")
-    @SuppressWarnings({
-        "unchecked",
-        "PMD.JUnitTestContainsTooManyAsserts",
-        "PMD.ProhibitPlainJunitAssertionsRule"
-    })
+    @SuppressWarnings("unchecked")
     @Disabled
     void generatesSodgForPacks(final String pack) throws IOException {
         final Xtory xtory = new XtSticky(new XtYaml(pack));
@@ -80,8 +74,8 @@ final class SodgTest {
 
     /**
      * Get the inclusion string from the Xtory object.
-     * @param xtory The Xtory object.
-     * @return The inclusion string.
+     * @param xtory The Xtory object
+     * @return The inclusion string
      */
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static String inclusion(final Xtory xtory) {

--- a/src/test/java/org/eolang/sodg/TrSodgTest.java
+++ b/src/test/java/org/eolang/sodg/TrSodgTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Tests for {@link TrSodg}.
- *
  * @since 0.0.2
  */
 final class TrSodgTest {


### PR DESCRIPTION
@yegor256

## Summary

This PR bumps `qulice-maven-plugin` from 0.24.0 to 0.27.6, fixes the resulting 138 violations across 30 files, and refines a few dependency declarations. It does not change the parent POM, eo-parser, cactoos, or tojos: each was tried but had to be reverted (see "Why some upgrades were skipped" below).

## Changes

### `pom.xml`
| Artifact | From | To | Notes |
|---|---|---|---|
| `com.qulice:qulice-maven-plugin` | 0.24.0 | 0.27.6 | qulice profile only |
| `com.yegor256:jping` | 0.0.3 | 0.1.0 | test scope |
| `xml-apis:xml-apis` | compile | runtime | not used in any `.java` source, only loaded at runtime by `jcabi-xml`; qulice 0.27.6 flags it as an unused compile dependency |
| `org.opentest4j:opentest4j` | n/a | 1.3.0 (test) | declared explicitly so qulice 0.27.6 can resolve `TestAbortedException` and `MultipleFailuresError` referenced via `Assumptions.assumeTrue` and `Assertions.assertAll` in `SodgTest` |

### Source (qulice 0.27.6 fixes, 138 violations, 30 files)
Following the project guideline of fixing rather than suppressing. Categories:
- **Javadoc** (~64 fixes): drop blank line before `@-tags`; drop trailing dots from `@param`/`@return`; align `@throws` with method signatures.
- **Strings** (16): replace literal `
` with `String.format("%n")` or `System.lineSeparator()` (`ProhibitLineSeparatorInStrings`).
- **Suppressions / locals** (19): drop unnecessary `@SuppressWarnings`; inline single-use locals.
- **Layout** (12): add empty line before first class member; attach fluent-call opening paren to previous line; remove empty line before closing brace.
- **Catalogs**: synchronized block -> `ReentrantLock`; field typed as `Map` instead of `ConcurrentHashMap`.
- **Instructions**: `@FunctionalInterface` annotation.
- **TrFinish, SodgFilesTest**: extract overlong lambda bodies to private helpers.
- **StMeasured**: explicit `StandardCharsets.UTF_8`.
- **ItsAngry**: drop redundant `else` after `throw`.
- **Depot, Saved**: use `Scalar` / `Unchecked` indirection so the constructor body is method-call-free (`ConstructorsCodeFreeCheck`).
- **`TrEnvelope` subclasses** (`TrSodg`, `TrDot`, `TrFinish`, `TrText`, `TrXembly`) and **`AttributeNotFoundException`**: narrow per-line `@checkstyle ConstructorsCodeFreeCheck` suppressions. These constructors must invoke the `xsline` `Train` builder API to satisfy the parent class contract; deferring would require an upstream API change.

## Why some upgrades were skipped

Each of the following was tried and reverted:

- **`com.jcabi:parent` 0.70.0 -> 0.73.1**: the new parent imports `junit-bom` 6.0.3, which requires JDK 17+. The CI matrix (`.github/workflows/mvn.yml`) still tests on JDK 11. Overriding `junit-bom` to 5.x worked for unit tests, but the integration tests run via `maven-invoker-plugin` still hit JDK-17 transitive deps brought in by the new parent.
- **`org.cactoos:cactoos` 0.57.0 -> 0.61.0**: cactoos 0.58 onwards is compiled to bytecode 61 (JDK 17). Anything older than JDK 17 fails to load it. Kept at 0.57.0 (last bytecode-52 line).
- **`com.yegor256:tojos` 0.18.5 -> 0.19.1**: tojos 0.19.x is built against cactoos 0.60.x; combined with our cactoos 0.57.0 pin it surfaces classpath issues on JDK 11. Kept at 0.18.5.
- **`org.eolang:eo-parser` 0.59.0 -> 0.61.0**: 0.60+ changes the parsed XMIR shape (e.g. `delta` instructions become `meta`), which breaks the SODG yaml test packs in `src/test/resources/org/eolang/maven/sodg/sodg-packs/`. Updating those packs is a separate, behavior-affecting change.

## Build verification

Verified locally on JDK 11 and JDK 21:

- `mvn clean install --errors --batch-mode -DskipITs` -> BUILD SUCCESS on both.
- `mvn clean verify -PskipTests,qulice --errors --batch-mode` -> BUILD SUCCESS on JDK 21.
- 19 unit tests pass.

Integration tests (`MjSodgIT`, the `maven-invoker-plugin` examples) require network access to `home.objectionary.com` (objectionary index lookup), which is blocked by the local sandbox. They exercise on CI as usual.

## CI status

- **All non-mvn checks green**: actionlint, codecov, copyrights, markdown-lint, ort, pdd, qulice, reuse, typos, xcop, yamllint.
- **`mvn (ubuntu-24.04, 23)`, `mvn (windows-2022, 23)`, `mvn (macos-15, 23)`**: all confirmed green on a previous push of this branch where `fail-fast: false` was temporarily enabled (commit b2b4257). On this final push they show "cancelled" only because the JDK 11 job in the same matrix fails first.
- **`mvn (ubuntu-24.04, 11)`: failure - pre-existing on `master`.** Every CI run on this repository since the master commit `5b92057b` (2026-01-08) has had this same `mvn (ubuntu-24.04, 11)` failure. Reproduced on:
  - https://github.com/objectionary/sodg-maven-plugin/actions/runs/25285069713 (`102-add-depot-tests`, 2026-05-03, identical pom to master)
  - Multiple `renovate/*` runs back to 2026-04-17.

  I bisected my own changes against this failure - reverting all my source and dependency changes (workflow file aside) to a tree identical to master still fails the same JDK 11 job. The breakage is in something the matrix pulls transitively (most likely an `eo-maven-plugin` 0.59.0 dependency that ships JDK-17 bytecode and is loaded by the IT projects via the local repo). The repo will need a separate fix (or to drop JDK 11 from the matrix); it is out of scope for this PR.

## Test plan

- [x] `mvn clean verify -PskipTests,qulice` passes locally (JDK 21).
- [x] `mvn clean install -DskipITs` passes locally on JDK 11 and JDK 21.
- [x] CI `qulice`, `codecov`, `actionlint`, `markdown-lint`, `pdd`, `reuse`, `typos`, `xcop`, `yamllint`, `copyrights`, `ort` all green.
- [x] CI `mvn (ubuntu-24.04, 23)`, `mvn (windows-2022, 23)`, `mvn (macos-15, 23)` all green (verified with `fail-fast: false` on prior commit).
- [ ] CI `mvn (ubuntu-24.04, 11)` - tracked separately, not introduced by this PR.

Ready for review.