### PR TITLE
bug(#159): close foreign tojos after SODG generation

### DIFF
--- a/src/main/java/org/eolang/sodg/MjSodg.java
+++ b/src/main/java/org/eolang/sodg/MjSodg.java
@@ -8,6 +8,7 @@ import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.util.Set;
+import java.util.function.Function;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
@@ -42,7 +43,11 @@ import org.cactoos.set.SetOf;
     requiresDependencyResolution = ResolutionScope.COMPILE,
     requiresProject = false
 )
-@SuppressWarnings({"PMD.ImmutableField", "PMD.AvoidProtectedFieldInFinalClass"})
+@SuppressWarnings({
+    "PMD.ImmutableField",
+    "PMD.AvoidProtectedFieldInFinalClass",
+    "PMD.ConstructorShouldDoInitialization"
+})
 public final class MjSodg extends AbstractMojo {
 
     /**
@@ -110,13 +115,9 @@ public final class MjSodg extends AbstractMojo {
     protected File targetDir;
 
     /**
-     * Cached tojos.
-     * @checkstyle VisibilityModifierCheck (5 lines)
+     * Foreign tojos.
      */
-    private final TjsForeign tojos = new TjsForeign(
-        () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignFormat),
-        () -> this.scope
-    );
+    private final Function<MjSodg, TjsForeign> tojos;
 
     /**
      * Shall we generate .xml files with SODGs?
@@ -195,7 +196,28 @@ public final class MjSodg extends AbstractMojo {
     @Parameter(defaultValue = "${plugin}", readonly = true)
     private PluginDescriptor descriptor;
 
+    /**
+     * Ctor.
+     */
+    public MjSodg() {
+        this(
+            mojo -> new TjsForeign(
+                () -> Catalogs.INSTANCE.make(mojo.foreign.toPath(), mojo.foreignFormat),
+                () -> mojo.scope
+            )
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param tjs Foreign tojos
+     */
+    MjSodg(final Function<MjSodg, TjsForeign> tjs) {
+        this.tojos = tjs;
+    }
+
     @Override
+    @SuppressWarnings("PMD.UnnecessaryLocalRule")
     public void execute() throws MojoFailureException {
         if (this.skip) {
             if (Logger.isInfoEnabled(this)) {
@@ -215,23 +237,38 @@ public final class MjSodg extends AbstractMojo {
                         "Setting generateDotFiles and not setting generateGraphFiles has no effect because .dot files require .graph files"
                     );
                 }
-                new SodgFiles(
-                    new ItsAngry(
-                        new ItsDefault(
-                            new Depot(this.xslMeasures),
-                            new MapOf<>(
-                                new MapEntry<>("generateSodgXmlFiles", this.generateSodgXmlFiles),
-                                new MapEntry<>("generateXemblyFiles", this.generateXemblyFiles),
-                                new MapEntry<>("generateXemblyFiles", this.generateXemblyFiles),
-                                new MapEntry<>("generateGraphFiles", this.generateGraphFiles),
-                                new MapEntry<>("generateDotFiles", this.generateDotFiles)
-                            )
+                try (TjsForeign tjs = this.tojos.apply(this)) {
+                    new SodgFiles(
+                        new ItsAngry(
+                            new ItsDefault(
+                                new Depot(this.xslMeasures),
+                                new MapOf<>(
+                                    new MapEntry<>(
+                                        "generateSodgXmlFiles", this.generateSodgXmlFiles
+                                    ),
+                                    new MapEntry<>(
+                                        "generateXemblyFiles", this.generateXemblyFiles
+                                    ),
+                                    new MapEntry<>(
+                                        "generateXemblyFiles", this.generateXemblyFiles
+                                    ),
+                                    new MapEntry<>(
+                                        "generateGraphFiles", this.generateGraphFiles
+                                    ),
+                                    new MapEntry<>(
+                                        "generateDotFiles", this.generateDotFiles
+                                    )
+                                )
+                            ),
+                            this.failOnXmirErrors
                         ),
-                        this.failOnXmirErrors
-                    ),
-                    this.sodgIncludes,
-                    this.sodgExcludes
-                ).generate(this.tojos.withXmir(), this.targetDir.toPath().resolve(MjSodg.DIR));
+                        this.sodgIncludes,
+                        this.sodgExcludes
+                    ).generate(
+                        tjs.withXmir(),
+                        this.targetDir.toPath().resolve(MjSodg.DIR)
+                    );
+                }
             } catch (final IOException exception) {
                 throw new MojoFailureException("Can't convert XMIR to SODG", exception);
             }

--- a/src/test/java/org/eolang/sodg/MjSodgTest.java
+++ b/src/test/java/org/eolang/sodg/MjSodgTest.java
@@ -5,11 +5,18 @@
 package org.eolang.sodg;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import com.yegor256.tojos.Tojo;
+import com.yegor256.tojos.Tojos;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
@@ -18,6 +25,7 @@ import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
 import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +36,24 @@ import org.junit.jupiter.params.ParameterizedTest;
  */
 @ExtendWith(MktmpResolver.class)
 final class MjSodgTest {
+
+    @Test
+    void closesForeignTojosAfterExecution(@Mktmp final Path temp) throws Exception {
+        final AtomicBoolean closed = new AtomicBoolean();
+        final MjSodg mojo = new MjSodg(
+            ignored -> new TjsForeign(
+                () -> new MjSodgTest.EmptyTojos(closed), () -> "compile"
+            )
+        );
+        mojo.targetDir = temp.toFile();
+        mojo.xslMeasures = temp.resolve("xsl-measures.json").toFile();
+        mojo.execute();
+        MatcherAssert.assertThat(
+            "foreign tojos should be closed after the mojo finishes",
+            closed.get(),
+            Matchers.is(true)
+        );
+    }
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/sodg/sodg-format", glob = "**.yaml")
@@ -55,6 +81,41 @@ final class MjSodgTest {
                     )
                 )
             );
+        }
+    }
+
+    /**
+     * Empty tojos that records whether it was closed.
+     * @since 0.0.0
+     */
+    private static final class EmptyTojos implements Tojos {
+
+        /**
+         * Closed marker.
+         */
+        private final AtomicBoolean closed;
+
+        /**
+         * Ctor.
+         * @param clsd Closed marker
+         */
+        EmptyTojos(final AtomicBoolean clsd) {
+            this.closed = clsd;
+        }
+
+        @Override
+        public Tojo add(final String name) {
+            throw new UnsupportedOperationException("Adding tojos is not expected");
+        }
+
+        @Override
+        public List<Tojo> select(final Predicate<Tojo> filter) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public void close() {
+            this.closed.set(true);
         }
     }
 }


### PR DESCRIPTION
Closes #159.

## What changed

- Create the foreign tojos handle when MjSodg#execute() runs, then close it with try-with-resources after SODG generation.
- Keep the Maven-facing no-arg constructor intact and add a package-private factory constructor for the regression test.
- Add a regression test that injects close-tracking Tojos and verifies close() is called after execution.

## Validation

- mvn -DskipITs -Dtest=MjSodgTest test -> 5 tests, 0 failures, 0 errors.
- git diff --check -> passed.
- gitleaks git --no-banner --redact --staged=false --log-level error -> passed.
- mvn -DskipITs test -> fails in existing DepotTest cases unrelated to this change: createsParentDirectoryForMeasuresFile and ejectsMeasuresPointingToDirectory.
- mvn clean verify -PskipTests,qulice with Java 21 -> no touched-file violations remain; fails on existing DepotTest style violations.