### PR TITLE
#157: fix Depot build failure — validate measures file eagerly

### DIFF
--- a/src/main/java/org/eolang/sodg/Depot.java
+++ b/src/main/java/org/eolang/sodg/Depot.java
@@ -33,7 +33,19 @@ final class Depot {
      * @param measures Measures
      */
     Depot(final File measures) {
-        this((Scalar<Map<String, Train<Shift>>>) () -> new MapOf<>(
+        if (measures.isDirectory()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "This is not a file but a directory, can't write to it: %s",
+                    measures
+                )
+            );
+        }
+        final File parent = measures.getParentFile();
+        if (parent != null && parent.mkdirs()) {
+            Logger.debug(Depot.class, "Directory created for %[file]s", measures);
+        }
+        final Map<String, Train<Shift>> trns = new MapOf<>(
             new MapEntry<>(
                 "sodg", Depot.measured(new TrSodg(Depot.loggingLevel()), measures)
             ),
@@ -45,7 +57,8 @@ final class Depot {
             new MapEntry<>(
                 "finish", Depot.measured(new TrFinish(Depot.loggingLevel()), measures)
             )
-        ));
+        );
+        this.trains = new Unchecked<>(new Sticky<>(() -> trns));
     }
 
     /**
@@ -53,7 +66,7 @@ final class Depot {
      * @param trns The trains
      */
     Depot(final Map<String, Train<Shift>> trns) {
-        this((Scalar<Map<String, Train<Shift>>>) () -> trns);
+        this.trains = new Unchecked<>(new Sticky<>(() -> trns));
     }
 
     /**
@@ -95,22 +108,11 @@ final class Depot {
      * @return Measured train
      */
     private static Train<Shift> measured(final Train<Shift> train, final File measures) {
-        if (measures.getParentFile().mkdirs()) {
-            Logger.debug(Depot.class, "Directory created for %[file]s", measures);
-        }
         if (!measures.getParentFile().exists()) {
             throw new IllegalArgumentException(
                 String.format(
                     "For some reason, the directory %s is absent, can't write measures to %s",
                     measures.getParentFile(),
-                    measures
-                )
-            );
-        }
-        if (measures.isDirectory()) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "This is not a file but a directory, can't write to it: %s",
                     measures
                 )
             );


### PR DESCRIPTION
Moved measures file validation from lazy Sticky scalar to
the Depot constructor. The directory-check and mkdirs now
run eagerly, preventing build failures when the measures
parent directory does not yet exist.