### PR TITLE
fix(#121): replace deprecated articulate/actions-markdownlint

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: articulate/actions-markdownlint@v1
+      - uses: DavidAnson/markdownlint-cli2-action@v23


### PR DESCRIPTION
The `articulate/actions-markdownlint` action used in `.github/workflows/markdown-lint.yml` is archived upstream; pinning it on `v1` works today but the repo accepts no fixes for new rule editions, Node runtime updates, or rule deprecations. Replace it with the actively maintained `DavidAnson/markdownlint-cli2-action`, which wraps the same `markdownlint` rule engine through `markdownlint-cli2` and stays current.

The workflow now runs `DavidAnson/markdownlint-cli2-action@v23`. The default `globs` of `*.{md,markdown}` matches the file set the old action covered for this repo: `README.md`, `CODE_OF_CONDUCT.md`, and `src/it/README.md`. No `markdownlint` config file has to be added because none existed before, and the v23 default rule set is the same `markdownlint v0.40` rules `articulate/actions-markdownlint@v1` carried.

Tested locally with `npx markdownlint-cli2 '*.md' '**/*.md'` from a fresh clone of the branch; the linter walks all 8 Markdown files and reports `0 error(s)`.

Closes #121