### PR TITLE
fix(#170): drop duplicate generateXemblyFiles map entry

### DIFF
--- a/src/main/java/org/eolang/sodg/ItsDefault.java
+++ b/src/main/java/org/eolang/sodg/ItsDefault.java
@@ -49,7 +49,6 @@ final class ItsDefault implements Instructions {
             new MapOf<>(
                 new MapEntry<>("generateSodgXmlFiles", false),
                 new MapEntry<>("generateXemblyFiles", false),
-                new MapEntry<>("generateXemblyFiles", false),
                 new MapEntry<>("generateGraphFiles", false),
                 new MapEntry<>("generateDotFiles", false)
             )

--- a/src/main/java/org/eolang/sodg/MjSodg.java
+++ b/src/main/java/org/eolang/sodg/MjSodg.java
@@ -222,7 +222,6 @@ public final class MjSodg extends AbstractMojo {
                             new MapOf<>(
                                 new MapEntry<>("generateSodgXmlFiles", this.generateSodgXmlFiles),
                                 new MapEntry<>("generateXemblyFiles", this.generateXemblyFiles),
-                                new MapEntry<>("generateXemblyFiles", this.generateXemblyFiles),
                                 new MapEntry<>("generateGraphFiles", this.generateGraphFiles),
                                 new MapEntry<>("generateDotFiles", this.generateDotFiles)
                             )


### PR DESCRIPTION
Resolves #170. The default constructor in `ItsDefault` and the `MapOf<>` built inside `MjSodg.execute()` both registered `generateXemblyFiles` twice as a map key. Because the second entry repeats the same value as the first, the duplication had no runtime effect; cactoos' `MapOf` silently kept one of the two bindings either way. The duplicate is purely a copy-paste residue.

The change removes one `MapEntry<>("generateXemblyFiles", ...)` from each call site. The four-key configuration that `ItsDefault.textInstructions` and `makeGraph` look up (`generateSodgXmlFiles`, `generateXemblyFiles`, `generateGraphFiles`, `generateDotFiles`) is preserved one-to-one, so the public behaviour of the mojo is unchanged.

`mvn -B -ntp clean compile` passes locally. `mvn -B -ntp clean test` reports the same two `DepotTest` failures already tracked in #157 (`createsParentDirectoryForMeasuresFile`, `rejectsMeasuresPointingToDirectory`) and `mvn -B -ntp -PskipTests,qulice clean verify` reports the same five `DepotTest`/qulice violations that already fail on `master` (master's `mvn` and `qulice` workflow runs are currently red). Neither failure set touches the two files this PR changes.

Closes #170
