### PR TITLE
#172: honour SOURCE_DATE_EPOCH in Disclaimer for reproducible builds

### DIFF
--- a/src/main/java/org/eolang/sodg/Disclaimer.java
+++ b/src/main/java/org/eolang/sodg/Disclaimer.java
@@ -5,6 +5,7 @@
 package org.eolang.sodg;
 
 import com.jcabi.manifests.Manifests;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -43,10 +44,28 @@ final class Disclaimer {
             " ",
             Manifests.read("EO-Dob"),
             ") on ",
-            ZonedDateTime.now(ZoneOffset.UTC).format(
-                DateTimeFormatter.ISO_INSTANT
-            ),
+            ZonedDateTime.ofInstant(
+                Disclaimer.resolved(System.getenv("SOURCE_DATE_EPOCH")), ZoneOffset.UTC
+            ).format(DateTimeFormatter.ISO_INSTANT),
             "; your changes will be discarded on the next build"
         );
+    }
+
+    /**
+     * Resolve the timestamp to embed, honouring {@code SOURCE_DATE_EPOCH} for
+     * reproducible builds (https://reproducible-builds.org/specs/source-date-epoch/)
+     * and falling back to the current time when it isn't set.
+     * @param epoch Value of the {@code SOURCE_DATE_EPOCH} environment variable, or
+     *  {@code null} if it isn't set
+     * @return The timestamp
+     */
+    static Instant resolved(final String epoch) {
+        final Instant now;
+        if (epoch == null) {
+            now = Instant.now();
+        } else {
+            now = Instant.ofEpochSecond(Long.parseLong(epoch));
+        }
+        return now;
     }
 }

--- a/src/test/java/org/eolang/sodg/DisclaimerTest.java
+++ b/src/test/java/org/eolang/sodg/DisclaimerTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.sodg;
+
+import java.time.Instant;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Disclaimer}.
+ * @since 0.27
+ */
+final class DisclaimerTest {
+
+    @Test
+    void resolvesFromSourceDateEpoch() {
+        MatcherAssert.assertThat(
+            "Timestamp does not match SOURCE_DATE_EPOCH",
+            Disclaimer.resolved("1700000000"),
+            Matchers.equalTo(Instant.ofEpochSecond(1_700_000_000L))
+        );
+    }
+
+    @Test
+    void resolvesSameInstantForSameSourceDateEpoch() {
+        MatcherAssert.assertThat(
+            "Two resolutions with the same SOURCE_DATE_EPOCH must be equal",
+            Disclaimer.resolved("1700000000"),
+            Matchers.equalTo(Disclaimer.resolved("1700000000"))
+        );
+    }
+
+    @Test
+    void fallsBackToNowWhenSourceDateEpochIsAbsent() {
+        MatcherAssert.assertThat(
+            "Timestamp must fall back to current time when SOURCE_DATE_EPOCH is unset",
+            Disclaimer.resolved(null),
+            Matchers.lessThanOrEqualTo(Instant.now())
+        );
+    }
+}


### PR DESCRIPTION
Closes #172.

`Disclaimer.toString()` appended `ZonedDateTime.now(ZoneOffset.UTC)` to the header written into
every generated `.sodg`/`.xe`/`.dot` artifact. Two builds of the same unchanged XMIR produced
byte-different output whose only difference was this timestamp, breaking reproducible-build
expectations and defeating content-addressed caching downstream.

Added support for the standard `SOURCE_DATE_EPOCH` reproducible-builds convention
(https://reproducible-builds.org/specs/source-date-epoch/): when set, its value (Unix epoch
seconds) is used as the disclaimer timestamp instead of the current time; when unset, behavior is
unchanged (falls back to `Instant.now()`).

Extracted the resolution logic into `Disclaimer.resolved(String)` (package-private, taking the
env var's value as a parameter) so it's directly unit-testable without needing to mutate process
environment variables.

## Test

Added `DisclaimerTest` covering:
- a `SOURCE_DATE_EPOCH` value resolves to the expected `Instant`
- resolution is deterministic for the same input
- the fallback path still returns something "now-ish" when unset

Ran the full test suite locally (31/31 pass) and `mvn clean verify -Pqulice` (`BUILD SUCCESS`).
