### PR TITLE
#193: regenerate .sodg when its mtime equals the source .xmir mtime

### DIFF
--- a/src/main/java/org/eolang/sodg/SodgFiles.java
+++ b/src/main/java/org/eolang/sodg/SodgFiles.java
@@ -74,7 +74,7 @@ final class SodgFiles {
             }
             final Path sodg = new Place(name).make(home, "sodg");
             final Path xmir = tojo.shaken();
-            if (sodg.toFile().lastModified() >= xmir.toFile().lastModified()) {
+            if (sodg.toFile().lastModified() > xmir.toFile().lastModified()) {
                 Logger.debug(
                     this, "Already converted %s to %[file]s (it's newer than the source)",
                     name, sodg

--- a/src/test/java/org/eolang/sodg/SodgFilesTest.java
+++ b/src/test/java/org/eolang/sodg/SodgFilesTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,6 +26,7 @@ import org.cactoos.set.SetOf;
 import org.eolang.parser.EoSyntax;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -79,6 +81,66 @@ final class SodgFilesTest {
                 ),
                 Matchers.equalTo(true)
             )
+        );
+    }
+
+    @Test
+    @ExtendWith(MktmpResolver.class)
+    void regeneratesWhenTimestampsAreEqual(@Mktmp final Path temp) throws IOException {
+        final Path home = temp.resolve("sodg");
+        final Collection<TjForeign> tojos = new SodgFilesTest.TjsXmir(
+            temp,
+            new MapOf<>(
+                new MapEntry<>(
+                    "app",
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > app",
+                        "  QQ.io.stdout > @",
+                        "    \"first\""
+                    )
+                )
+            )
+        ).asTojos();
+        final SodgFiles files = new SodgFiles(
+            new ItsDefault(
+                new Depot(temp.resolve("measures.csv").toFile()),
+                new MapOf<>(
+                    new MapEntry<>("generateSodgXmlFiles", false),
+                    new MapEntry<>("generateXemblyFiles", false),
+                    new MapEntry<>("generateGraphFiles", false),
+                    new MapEntry<>("generateDotFiles", false)
+                )
+            ),
+            new SetOf<>("**"),
+            new SetOf<>()
+        );
+        files.generate(tojos, home);
+        final Path sodg = home.resolve("org")
+            .resolve("eolang")
+            .resolve("sodg")
+            .resolve("examples")
+            .resolve("app.sodg");
+        final Path xmir = temp.resolve("app.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > app",
+                    "  QQ.io.stdout > @",
+                    "    \"second\""
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        Files.setLastModifiedTime(
+            xmir, FileTime.fromMillis(sodg.toFile().lastModified())
+        );
+        files.generate(tojos, home);
+        MatcherAssert.assertThat(
+            "SODG must be regenerated when its mtime equals the source XMIR's mtime",
+            new String(Files.readAllBytes(sodg), StandardCharsets.UTF_8),
+            Matchers.containsString("73-65-63-6F-6E-64")
         );
     }
 


### PR DESCRIPTION
Closes #193.

The freshness check in `SodgFiles.generate()` treated an equal timestamp as "definitely fresh" and skipped regeneration, silently serving a stale `.sodg` whenever the modified `.xmir` landed on the same mtime tick as the existing output. The comparison is now strictly `>`.

The new test generates a `.sodg`, rewrites the source `.xmir` with different content, forces its mtime to exactly match the output's, re-runs `generate()`, and asserts the `.sodg` now encodes the new content (the hexed `"second"` literal). Verified the test fails on the previous `>=` comparison.

`mvn verify -Pqulice -DskipITs`: 32 tests, 0 failures, qulice clean.
