### PR TITLE
#186: refer to eo.failOnXmirErrors by its full property name in ItsAngry message

### DIFF
--- a/src/main/java/org/eolang/sodg/ItsAngry.java
+++ b/src/main/java/org/eolang/sodg/ItsAngry.java
@@ -41,7 +41,7 @@ final class ItsAngry implements Instructions {
         final XML document = new XMLDocument(xmir);
         if (!document.nodes("/object/errors").isEmpty() && this.exit) {
             final String message = String.format(
-                "Failing SODG generation, since the object in '%s' contains errors ('failOnXmirErrors=true'):%n%s",
+                "Failing SODG generation, since the object in '%s' contains errors ('eo.failOnXmirErrors=true'):%n%s",
                 xmir, document
             );
             Logger.error(this, message);

--- a/src/test/java/org/eolang/sodg/ItsAngryTest.java
+++ b/src/test/java/org/eolang/sodg/ItsAngryTest.java
@@ -58,6 +58,7 @@ final class ItsAngryTest {
             ).getMessage(),
             Matchers.allOf(
                 Matchers.containsString("Failing SODG generation"),
+                Matchers.containsString("'eo.failOnXmirErrors=true'"),
                 Matchers.containsString("broken")
             )
         );


### PR DESCRIPTION
Closes #186.

The `ItsAngry` failure message referred to the flag as `failOnXmirErrors`, while the Maven property declared in `MjSodg` is `eo.failOnXmirErrors` — so the hint pointed users at a `-D` flag that has no effect. The message now shows the fully-qualified property name, and `failsBrokenXmir` asserts the exact `'eo.failOnXmirErrors=true'` fragment so the two can't drift apart again.

`mvn verify -Pqulice -DskipITs`: 31 tests, 0 failures, qulice clean.
