### PR TITLE
#179: deduplicate IT poms GAV and upgrade ORT to 90.0.0

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -16,13 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      # @todo #157:30min Upgrade ORT once the SPDX crash is fixed upstream.
-      #  ORT 85.1.0 introduced a stricter SPDX reporter that throws
-      #  NoSuchElementException when the dependency graph is incomplete, triggered by
-      #  src/it/generates-sodg-files/pom.xml using the @project.version@
-      #  Maven filter placeholder which is unresolvable outside a Maven build.
-      #  Rolled back to 85.0.0. Upgrade once ORT fixes the SPDX reporter crash, or
-      #  once the fibonacci invoker template is updated to use resolvable versions.
       - uses: oss-review-toolkit/ort-ci-github-action@v1
         with:
-          image: 'ghcr.io/oss-review-toolkit/ort:85.0.0'
+          image: 'ghcr.io/oss-review-toolkit/ort:90.0.0'

--- a/src/it/fails-on-broken-xmir/pom.xml
+++ b/src/it/fails-on-broken-xmir/pom.xml
@@ -11,8 +11,8 @@
     <version>0.70.0</version>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>examples</artifactId>
-  <version>@project.version@</version>
+  <artifactId>it-fails-on-broken-xmir</artifactId>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Generates SODG Files</name>
   <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files from this XMIR</description>

--- a/src/it/generates-sodg-files/pom.xml
+++ b/src/it/generates-sodg-files/pom.xml
@@ -11,8 +11,8 @@
     <version>0.70.0</version>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>examples</artifactId>
-  <version>@project.version@</version>
+  <artifactId>it-generates-sodg-files</artifactId>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Generates SODG Files</name>
   <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files from this XMIR</description>

--- a/src/it/json-foreigns/pom.xml
+++ b/src/it/json-foreigns/pom.xml
@@ -11,8 +11,8 @@
     <version>0.70.0</version>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>examples</artifactId>
-  <version>@project.version@</version>
+  <artifactId>it-json-foreigns</artifactId>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Generates SODG Files</name>
   <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files from this XMIR</description>

--- a/src/it/processes-broken-xmir/pom.xml
+++ b/src/it/processes-broken-xmir/pom.xml
@@ -11,8 +11,8 @@
     <version>0.70.0</version>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>examples</artifactId>
-  <version>@project.version@</version>
+  <artifactId>it-processes-broken-xmir</artifactId>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Generates SODG Files</name>
   <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files from this XMIR</description>

--- a/src/it/without-pom/pom.xml
+++ b/src/it/without-pom/pom.xml
@@ -11,8 +11,8 @@
     <version>0.70.0</version>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>examples</artifactId>
-  <version>@project.version@</version>
+  <artifactId>it-without-pom</artifactId>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Generates SODG Files without SODG plugin in pom.xml</name>
   <description>This tests compiles EO programs to XMIR and then checks that we can generate SODG files without the plugin in pom.xml</description>


### PR DESCRIPTION
Closes #179. Expected to also resolve #189.

Two changes, one cause: the `ort` check has been red because the pinned 85.0.0 engine can't compile the floating `@v1` action's `evaluator.rules.kts` (#189), while the upgrade path was blocked by the SPDX reporter crash on the unresolvable `@project.version@` Maven placeholder in the IT poms (the #179 puzzle).

- The five invoker IT poms now declare resolvable GAVs (`org.eolang:it-<test-name>:1.0.0`) instead of `org.eolang:examples:@project.version@`; the plugin-version placeholder stays where the invoker actually filters it (`without-pom` takes the version via `invoker.properties`).
- `ort.yml` upgrades the image to `ghcr.io/oss-review-toolkit/ort:90.0.0` and drops the `@todo` puzzle comment.

Verified locally: `mvn clean install -DskipTests -DskipITs=false` — all five ITs pass (Passed: 5, Failed: 0). The ORT engine itself is validated by this PR's own `ort` check.
