### PR TITLE
#191: honour SOURCE_DATE_EPOCH in TrSodg

### DIFF
--- a/src/main/java/org/eolang/sodg/TrSodg.java
+++ b/src/main/java/org/eolang/sodg/TrSodg.java
@@ -32,9 +32,19 @@ final class TrSodg extends TrEnvelope {
     /**
      * Ctor.
      * @param level Logging level
-     * @checkstyle ConstructorsCodeFreeCheck (60 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (5 lines)
      */
     TrSodg(final Level level) {
+        this(level, System.getenv("SOURCE_DATE_EPOCH"));
+    }
+
+    /**
+     * Ctor.
+     * @param level Logging level
+     * @param epoch Reproducible build timestamp
+     * @checkstyle ConstructorsCodeFreeCheck (60 lines)
+     */
+    TrSodg(final Level level, final String epoch) {
         super(
             new TrLogged(
                 new TrWith(
@@ -73,7 +83,9 @@ final class TrSodg extends TrEnvelope {
                                     String.format(
                                         "value %s",
                                         new HexedUtf(
-                                            ZonedDateTime.now(ZoneOffset.UTC).format(
+                                            ZonedDateTime.ofInstant(
+                                                Disclaimer.resolved(epoch), ZoneOffset.UTC
+                                            ).format(
                                                 DateTimeFormatter.ISO_INSTANT
                                             )
                                         ).asString()

--- a/src/test/java/org/eolang/sodg/TrSodgTest.java
+++ b/src/test/java/org/eolang/sodg/TrSodgTest.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.sodg;
 
+import com.yegor256.xsline.Xsline;
+import java.io.IOException;
 import java.util.logging.Level;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
@@ -11,6 +13,8 @@ import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
 import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
 /**
@@ -18,6 +22,23 @@ import org.junit.jupiter.params.ParameterizedTest;
  * @since 0.0.2
  */
 final class TrSodgTest {
+
+    @Test
+    void usesSourceDateEpochForTimeMeta() throws IOException {
+        MatcherAssert.assertThat(
+            "The time meta does not match SOURCE_DATE_EPOCH",
+            new Xsline(
+                new TrSodg(Level.FINEST, "1700000000")
+            ).pass(
+                new EoSyntax("[] > foo").parsed()
+            ).xpath(
+                "//sodg/i[@name='meta'][a[1]='$meta-time']/a[2]/text()"
+            ),
+            Matchers.contains(
+                new HexedUtf("2023-11-14T22:13:20Z").asString()
+            )
+        );
+    }
 
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/maven/sodg/sodg-packs/", glob = "**.yaml")


### PR DESCRIPTION
## Summary

Fixes #191.

`TrSodg` now uses `SOURCE_DATE_EPOCH` for the semantic `meta-time`
instruction, matching the reproducible timestamp behavior already used by
`Disclaimer`. When the variable is absent, generation still falls back to the
current time.

## Changes

- Resolve the `TrSodg` timestamp through `Disclaimer.resolved`.
- Add a regression test for the exact `meta-time` instruction generated from a
  fixed epoch.

## Testing

- `mvn -q -DskipITs -Dtest=TrSodgTest#usesSourceDateEpochForTimeMeta test`
- `mvn -q -DskipITs -Dtest=TrSodgTest test`
- `mvn clean install -Pqulice`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and
ran the listed checks locally.