### PR TITLE
Use a CSV extension for the default XSL measurements file

### DIFF
--- a/src/main/java/org/eolang/sodg/MjSodg.java
+++ b/src/main/java/org/eolang/sodg/MjSodg.java
@@ -67,7 +67,7 @@ public final class MjSodg extends AbstractMojo {
     @Parameter(
         property = "eo.sodg.xslMeasuresFile",
         required = true,
-        defaultValue = "${project.build.directory}/eo/xsl-measures.json"
+        defaultValue = "${project.build.directory}/eo/xsl-measures.csv"
     )
     protected File xslMeasures;
 

--- a/src/test/java/org/eolang/sodg/MjSodgTest.java
+++ b/src/test/java/org/eolang/sodg/MjSodgTest.java
@@ -18,6 +18,7 @@ import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
 import org.eolang.xax.XtoryMatcher;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,5 +57,18 @@ final class MjSodgTest {
                 )
             );
         }
+    }
+
+    @Test
+    void usesCsvExtensionForDefaultMeasurementsPath() {
+        MatcherAssert.assertThat(
+            "The default measurements file must match StMeasured's CSV output",
+            new UncheckedText(
+                new TextOf(MjSodg.class.getResource("/META-INF/maven/plugin.xml"))
+            ).asString(),
+            Matchers.containsString(
+                "default-value=\"${project.build.directory}/eo/xsl-measures.csv\""
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Change MjSodg's default XSL measurements path from `.json` to `.csv` to match StMeasured's CSV output.
- Add a regression test for the generated plugin descriptor default.

Fixes #192.

## Test plan

- [x] `mvn -Dtest=MjSodgTest -DskipITs test --batch-mode`
- [x] `git diff --check`
